### PR TITLE
Dependabot for GitHub actions versions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "housekeeping"
+    groups:
+      all-github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
#65 will introduce some GitHub actions versions. Should keep these updated.