### PR TITLE
Exclude useless files from website bundle

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,6 +36,9 @@ exclude:
   - vendor/
   - Gemfile
   - Gemfile.lock
+  - CONTRIBUTING.md
+  - LICENSE
+  - README.md
 
 markdown: kramdown
 


### PR DESCRIPTION
I don't think it's terribly useful to have files like [`README.md`](https://github-pages.ucl.ac.uk/open-source/README.md) or [`LICENSE`](https://github-pages.ucl.ac.uk/open-source/LICENSE) and [`CONTRIBUTING.md`](https://github-pages.ucl.ac.uk/open-source/CONTRIBUTING.md) hosted on the website.