### PR TITLE
Disable `proselint.Very`

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -9,6 +9,7 @@ BasedOnStyles = proselint,\
 
 # Disable
 Vale.Spelling = NO
+proselint.Very = NO
 
 # Ignore lines starting with GitHub alerts syntax
 BlockIgnores = (?s)> \[!(CAUTION|IMPORTANT|NOTE|TIP|WARNING)\](\n|$)


### PR DESCRIPTION
It's a shame I can't demote it from an error to a warning