### PR TITLE
Ignore 'too many request' failures.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,6 @@ jobs:
         with:
           # nice to check a few specific root-level markdown files (README.md etc) for valid links,
           # but the main thing to check is the rendered website (in the `open-source` directory)
-          args: "--no-progress --verbose --github-token ${{ secrets.GITHUB_TOKEN }} -- README.md CONTRIBUTING.md open-source/"
+          args: "--accept 200,429 --no-progress --verbose --github-token ${{ secrets.GITHUB_TOKEN }} -- README.md CONTRIBUTING.md open-source/"
           fail: true
           jobSummary: true


### PR DESCRIPTION
It might mask problems, but it's a balance.
During periods of several builds, I've noticed a few pages return 429 (too many requests).