### PR TITLE
document page and last two years reports

### DIFF
--- a/ospo/documents.md
+++ b/ospo/documents.md
@@ -1,0 +1,18 @@
+---
+layout: default
+title: documents
+crumbs:
+  - link: /ospo/documents.html
+    text: "OSPO documents"
+---
+
+# UCL's OSPO Documents
+
+## Yearly Reports
+
+- [2025](./documents/reports/2025report.html)
+- [2024](./documents/reports/2024report.html)
+
+## Activity Reports
+
+- [2024-06 OSS London Breakfast club](./documents/00-preOSPO/20240627-OSSBreakfastClub.html)

--- a/ospo/documents/reports/2024report.md
+++ b/ospo/documents/reports/2024report.md
@@ -1,0 +1,84 @@
+---
+layout: report
+title: 2024 report
+date: 2024-12-22
+category: report
+author: David Pérez-Suárez
+crumbs:
+  - link: /ospo/documents.html
+    text: "OSPO documents"
+  - link: /ospo/documents.html#yearly-reports
+    text: "Yearly reports"
+  - link: /ospo/documents/reports/2024
+    text: "2024"
+---
+
+In October of 2021 I received a scholarship to attend [OSPOCon Europe in London][ospocon21].
+This scholarship was provided by the [Sloan Foundation][sloan] where they were looking to support the development of Open Source Programme Offices (OSPOs) in university contexts.
+
+Before I attended that conference I knew very little of what an OSPO was, I was aware, however, of some Open Source efforts in universities like the defunct [OSSWatch][osswatch] in University of Oxford or the [CRISOL][crisol] group in Carlos III university in Madrid.
+
+In that conference I heard about the OSPO at the Rochester Institute of Technology ([Open@RIT][rit]), and it was in that instant that I saw that UCL should have one too! 
+Mostly as much of the things we do in ARC is aligned with what Open@RIT was doing, but also because we need to have a body to advocate for Open Source within the university and collaborate with other institutions on those matters.
+On that conference I also learnt other things like [Inner Source][w-innersource], what OSPOs are outside the academic context and much more.
+
+However, it was not till this year when things started to fall in place to move the creation of an OSPO in UCL. 
+Mostly, thanks to the Open Source Research Toolkit funding from ARC's research themes that we got this year.
+
+All started in a conference marathon in February where I attended four conference in a week, [CHAOSSCon][chaosscon24], [EU Open Source Policy Summit][euosps2024], [FOSDEM][fosdem24] and the [State of Open Con][soocon24].
+Attending to those conference provide me with a set of contacts that helped me understand what was required and next steps.
+
+One of these person was Jacob Green from [OSPO++][ia-ospo++], a network of OSPOs in universities, governments, and civic institutions.
+He was essential on knowing what to do.
+
+Thanks to him we organised the first Open Source Breakfast Club in London where few of us from UCL met various Open Source community representatives (CHAOSS, EOF, Matrix, Moodle, Mozilla, FINOS, OpenUK) and discussed what interactions could a University have with those communities (read [the whole report of the first open source breakfast][ossbclub] in London).
+Additionally, thanks to Jacob I managed to get a spot at [UN's OSPO for good symposium][ospo4good] and [What's next for Open Source?][NYworkshop] workshop.
+Those two events helped us to understand how organisations such as UN, national and local governments, industry and research institutions collaborate through OSPOs to tackle the [Sustainable Development Goals][sdg] ([read our report of the OSPO for good][ospo4good-report]).
+
+Between Jacob and I, we organised a panel at the [Open Source , Ethics & Innovation in AI][turing-event], a Turing's Way Practitioner's event hub last November in London.
+There, besides count with the participation of [Digital Science][ds], the French goverment OSPO, [FINOS][finos] (the fintech open source foundation), the [Tech Transfer and Open Source office from Coppin State University][coppinU] and with UCL's [Miguel Xochicale][mxochicale] giving a perspective on Open Source and medical tech transfer.
+
+
+This year we submitted three talks at various events through out the year, and the three were accepted.
+They were at [UCL Open Science & Scholarship Conference][ucl-osci], [ARC's Festival of Digital Research, Innovation & Scholarship][arc-fest] and at [RSECon24][rsecon].
+All of them were well received and sparked the conversation about Academic OSPOs within UCL and UK universities.
+
+
+Additionally, as per the numerous open source contributions happening in UCL, I'd like to mention the one from last summer by Saima Abdus.
+Saima has been ARC's first ever [In2Research][in2research] intern, and worked with ARC and NIU RSEs [expanding BrainGlobe's atlas with Axolotl's brain][bg-axolotl].
+Also, this year was when the Science Clusters launched the first [OSCARS Open Call for Open Science projects and services][oscars] and our colleague David Stansby was one of the awardees for the [HEFTIE (Handling Enormous Files from Tomographic Imaging Experiments) project][oscars-heftie].
+And just before Christmas we run in ARC the first [Winter OSS Good-first-issue-athon][arc-gfi], an event to introduce to people to contribute to Open Source projects tackling issues that they need help with.
+
+
+Overall, this year has been a good start towards the OSPO.
+Full of activities and outreach to find OSPO supporters between the university and the open source community.
+Let's see what 2025 brings.
+
+[ospocon21]: https://events.linuxfoundation.org/archive/2021/ospocon-europe/
+[sloan]: https://sloan.org
+[osswatch]: http://oss-watch.ac.uk/
+[rit]: https://www.rit.edu/research/open/
+[w-innersource]: https://en.wikipedia.org/wiki/Inner_source
+[chaosscon24]: https://chaoss.community/chaosscon-2024-eu/
+[euosps2024]: https://interoperable-europe.ec.europa.eu/collection/open-source-observatory-osor/event/eu-open-source-policy-summit-2024
+[fosdem24]: https://archive.fosdem.org/2024/
+[soocon24]: https://stateofopencon.com/soocon-2024/
+[ia-ospo++]: https://web.archive.org/web/20240819044533/http://ospoplusplus.com/
+[ossbclub]: ../FIXME
+[ospo4good]: https://www.un.org/digital-emerging-technologies/content/ospos-good-2024
+[NYworkshop]: https://events.linuxfoundation.org/whatsnext4oss/
+[ospo4good-report]: https://blogs.ucl.ac.uk/research-software-development/arc-at-uns-ospos-for-good-and-whats-next-for-oss/
+[sdg]: https://en.wikipedia.org/wiki/Sustainable_Development_Goals
+[turing-event]: https://www.eventsforce.net/turingevents/frontend/reg/titem.csp?pageID=163355&eventID=388
+[finos]: https://www.finos.org/
+[ds]: https://www.digital-science.com/
+[coppinU]: https://www.coppin.edu/academics/colleges-and-schools/college-business
+[mxochicale]: https://profiles.ucl.ac.uk/91071-miguel-xochicale
+[ucl-osci]: https://blogs.ucl.ac.uk/open-access/2024/06/13/ucl-open-science-scholarship-conference-2024-programme-now-available/
+[arc-fest]: https://www.ucl.ac.uk/advanced-research-computing/events/2024/jun/festival-digital-research-scholarship
+[rsecon]: https://rsecon24.society-rse.org/
+[bg-axolotl]: https://brainglobe.info/blog/axolotl-atlas-added.html
+[in2research]: https://in2scienceuk.org/in2research/
+[oscars]: https://oscars-project.eu/
+[oscars-heftie]: https://oscars-project.eu/projects/heftie-handling-enormous-files-tomographic-imaging-experiments
+[arc-gfi]: https://www.ucl.ac.uk/advanced-research-computing/events/2024/dec/arc-winter-oss-good-first-issue-athon

--- a/ospo/documents/reports/2024report.md
+++ b/ospo/documents/reports/2024report.md
@@ -28,7 +28,7 @@ Mostly, thanks to the Open Source Research Toolkit funding from ARC's research t
 All started in a conference marathon in February where I attended four conference in a week, [CHAOSSCon][chaosscon24], [EU Open Source Policy Summit][euosps2024], [FOSDEM][fosdem24] and the [State of Open Con][soocon24].
 Attending to those conference provide me with a set of contacts that helped me understand what was required and next steps.
 
-One of these person was Jacob Green from [OSPO++][ia-ospo++], a network of OSPOs in universities, governments, and civic institutions.
+One of these people was Jacob Green from [OSPO++][ia-ospo++], a network of OSPOs in universities, governments, and civic institutions.
 He was essential on knowing what to do.
 
 Thanks to him we organised the first Open Source Breakfast Club in London where few of us from UCL met various Open Source community representatives (CHAOSS, EOF, Matrix, Moodle, Mozilla, FINOS, OpenUK) and discussed what interactions could a University have with those communities (read [the whole report of the first open source breakfast][ossbclub] in London).
@@ -36,7 +36,7 @@ Additionally, thanks to Jacob I managed to get a spot at [UN's OSPO for good sym
 Those two events helped us to understand how organisations such as UN, national and local governments, industry and research institutions collaborate through OSPOs to tackle the [Sustainable Development Goals][sdg] ([read our report of the OSPO for good][ospo4good-report]).
 
 Between Jacob and I, we organised a panel at the [Open Source , Ethics & Innovation in AI][turing-event], a Turing's Way Practitioner's event hub last November in London.
-There, besides count with the participation of [Digital Science][ds], the French goverment OSPO, [FINOS][finos] (the fintech open source foundation), the [Tech Transfer and Open Source office from Coppin State University][coppinU] and with UCL's [Miguel Xochicale][mxochicale] giving a perspective on Open Source and medical tech transfer.
+There, besides count with the participation of [Digital Science][ds], the French government OSPO, [FINOS][finos] (the fintech open source foundation), the [Tech Transfer and Open Source office from Coppin State University][coppinU] and with UCL's [Miguel Xochicale][mxochicale] giving a perspective on Open Source and medical tech transfer.
 
 
 This year we submitted three talks at various events through out the year, and the three were accepted.

--- a/ospo/documents/reports/2025report.md
+++ b/ospo/documents/reports/2025report.md
@@ -1,0 +1,76 @@
+---
+layout: default
+title: 2025 report
+date: 2025-12-23
+category: report
+author: David Pérez-Suárez
+crumbs:
+  - link: /ospo/documents.html
+    text: "OSPO documents"
+  - link: /ospo/documents.html#yearly-reports
+    text: "Yearly reports"
+  - link: /ospo/documents/reports/2025
+    text: "2025"
+---
+
+2025 started strong with our participation in [FOSDEM][fosdem25].
+Whereas in 2024 only I (David PS) went, this year we sent a delegation of 9 ARC members, giving 3 talks in different devrooms by Chris and Miguel.
+Also, during that weekend, we started talking with Clare Dillon, community manager from [CURIOSS][curioss], a community of University and Research Institution OSPOs.
+By April, UCL was already part of CURIOSS.
+In a similar manner, after a conference Mosè attended last year, we become in February associate members of the [High Performance Software Foundation (HSPF)][hspf], a hub for open source high performance software supported by the Linux Foundation.
+
+
+In April we put together a proposal for [Measuring Impact of UCL's Open source for Data Empowered Society][OSPO-DES] led by ARC and NIU to work out Open Source impact in and by UCL.
+Unfortunately the proposal was not successful, but its development helped to strengthen contacts across the university and beyond.
+A part of what was proposed there was then repurposed as an ARC internal seed project which was successful and we analysed almost 1,000 repositories developed within UCL.
+
+
+Though a few people in UCL has been involved in the Google Summer Of Code, this year marks the first when a department within UCL got accepted as an organisation, NIU got XX GSoC contributors working on various of their Open Source projects.
+Before the application period closed  we run an [informative event where we invited all the known GSoC mentors within UCL][ucl-gsoc] to talk about their projects.
+At the end of the summer at least three UCL members (Sofia for NIU, Saransh for NumFOCUS and David for Open Astronomy) attended at the GSoC mentor summit in Munich, Germany.
+The summit was an opportunity to meet other participating organisations and Google's OSPO team.
+
+
+But NIU didn't stop at GSoC! They run [the first Open Software Week][niu-osweek], a week long in-person workshop where they run a set of training sessions on the tools they develop and maintain, together with a career clinic and finished with a hackday.
+The event was a success and they've already [announced the second edition for 2026][niu-osweek26].
+
+
+If this was not enough for a successful year for NIU, their [Brain Globe initiative was awarded the 2025 International prize by the Neuro-Irv and Helga Cooper Foundation][bg-award] last October.
+
+
+Regarding Open-Source activities, Miguel Xochicale lead a full-day workshop on [Healing Through Collaboration: Open-Source Software in Surgical, Biomedical and AI Technologies][surgical-ws].
+This year was also when [UCL's Linux User Group][ucl-lug] was formed.
+Started as a Linux Install party in March and have hosted monthly events since the academic year started, helping students and staff to give a new life to their old laptops.
+We also double the number of good-first-issue-athons from last year.
+Additionally, we run one during the [ARC's Festival of Digital Research, Innovation & Scholarship][arc-festival] in June and another one at the start of December.
+
+
+As an OSPO, we co-led with CURIOSS a Birds of a Feather session at RSECon titled ["Discovering Academic Open Source"][rsecon-bof] -which outcome will be available early next year- and participated as speaker in the workshop ["From code to contributions: exploring open source culture in academia"][rsecon-osacademia].
+
+And we've collaborated with the [OpenForumEurope][ofe] in the recording of the first masterclass for the OpenForum Academy.
+You will see it when it gets published sometime in 2026.
+
+
+<!-- We received Todd Grappone from UCLA's OSPO (Oct '24) and Stephen Walli from Semester of code (Feb)  -->
+Finally, this year we've got a draft for UCL's OSPO business case, which we will be finishing and presenting it next February at UCL's Open Science & Scholarship Committee.
+
+
+2026 will be a year of celebration, let's make UCL's 200 anniversary the start of a centralised OSPO.
+
+[fosdem25]: https://archive.fosdem.org/2025/
+[curioss]: https://curioss.org/
+[hspf]: https://hpsf.io/
+[OSPO-DES]: FIXME - add zenodo
+[ucl-gsoc]: https://blogs.ucl.ac.uk/research-software-development/arc-%E2%9D%A4-google-summer-of-code/
+[niu-osweek]: https://neuroinformatics.dev/open-software-summer-school/2025/index.html
+[niu-osweek26]:https://neuroinformatics.dev/open-software-summer-school/index.html
+[bg-award]: https://www.sainsburywellcome.org/web/research-news/brainglobe-initiative-wins-2025-international-prize
+[ucl-lug]: https://github-pages.ucl.ac.uk/linux/
+[arc-festival]: https://www.ucl.ac.uk/advanced-research-computing/events/2025/jul/festival-digital-research-innovation-scholarship
+[surgical-ws]: https://www.hamlynsymposium.org/events/healing-through-collaboration-open-source-software-in-surgical-biomedical-and-ai-technologies/
+[rsecon-bof]: https://virtual.oxfordabstracts.com/event/75166/submission/142
+[rsecon-osacademia]: https://virtual.oxfordabstracts.com/event/75166/submission/99
+[ofe]: https://openforumeurope.org/
+
+
+


### PR DESCRIPTION
This page will list any information of past events and yearly reports

This solves #84 by providing a link. Still this doesn't solve the question of the preOSPO path name.
