### PR TITLE
Adds funding opportunities page extracted from CURIOSS

### DIFF
--- a/.github/rss_2_yaml.py
+++ b/.github/rss_2_yaml.py
@@ -1,0 +1,36 @@
+from argparse import ArgumentParser
+import hashlib
+from pathlib import Path
+
+import feedparser
+import yaml
+
+def grab_funding(output_dir="_data/"):
+    """
+    Queries CURIOSS RSS feed and creates a yaml file for jekyll to consume.
+
+    Jekyll expect the data files under the `_data` directory.
+    """
+    output_dir = Path(output_dir)
+    h = hashlib.new('sha256')
+    feed = feedparser.parse("https://curioss.org/resources/funding-opportunities/index.xml")
+
+    output_dict = dict()
+
+    for entry in feed['entries']:
+        h.update(entry['title'].encode())
+        output_dict[h.hexdigest()] = {
+            'title': entry['title'],
+            'url': entry['link'],
+            'description': entry['description'].replace('$', '\\$'),
+        }
+
+    with open(output_dir/'funding.yaml', 'w') as f:
+        yaml.dump(output_dict, stream=f)
+
+if __name__ == '__main__':
+   parser = ArgumentParser(description="Grab and generates a yaml file for Jekyll")
+   parser.add_argument('--outdir', '-o', default='_data',
+                       help='The directory where to save the file')
+   arguments= parser.parse_args()
+   grab_funding(output_dir=arguments.outdir)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.13'
-          cache: 'pip' # caching pip dependencies
       - run: pip install pyyaml feedparser
       - name: Update funding opportunities
         run: python .github/rss_2_yaml.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Set Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip' # caching pip dependencies
+      - run: pip install pyyaml feedparser
+      - name: Update funding opportunities
+        run: python .github/rss_2_yaml.py
       - name: Build
         uses: actions/jekyll-build-pages@v1
       # The next step uploads a "special" artifact used by the

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
  push:
    branches: ["main"]
  pull_request:
+ schedule:
+   - cron: "27 0 * * 1,4"
 
 permissions:
   contents: read

--- a/_includes/funding.html
+++ b/_includes/funding.html
@@ -1,0 +1,8 @@
+{% assign details = funding_op[1] %}
+
+<h3> <a href="{{ details.url }}"> {{ details.title }}</a> </h3>
+
+<div>
+{{ details.description }}
+</div>
+

--- a/funding.md
+++ b/funding.md
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Funding opportunities
+permalink: /funding/
+crumbs:
+  - link: "/funding/"
+    text: "funding"
+
+---
+
+## Funding opportunities
+
+The below funding opportunities are regularly updated from the listing in [CURIOSS funding site](https://curioss.org/resources/funding-opportunities/).
+
+<div class="row-fluid">
+{% assign sorted_funding = site.data.funding | sort %}
+{% for funding_op in sorted_funding %}
+  <div class="span6" style="padding-bottom:15px">{% include funding.html funding_op=funding_op %}</div>
+  {% cycle '', '</div>' %}
+  {% cycle '', '<div class="row-fluid">' %}
+{% endfor %}
+</div>
+


### PR DESCRIPTION
It also includes the mechanics to download them from the feed.

This comes from CURIOSS's sharing working group, which have generated a [common place where to keep the open source related calls](https://curioss.org/resources/funding-opportunities/) and provides an RSS feed for different institutions to show in their sites.

At the moment, the RSS feed only includes title, url and description. I'll ask to include more details so we can filter the ones more applicable to us.

